### PR TITLE
fix: 发布时切换到官方 npm registry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,7 +92,9 @@ jobs:
         run: pnpm test
 
       - name: Publish to npm
-        run: pnpm changeset publish
+        run: |
+          echo "@txjs:registry=https://registry.npmjs.org/" >> .npmrc
+          pnpm changeset publish
         env:
           NPM_CONFIG_TOKEN: ${{ secrets.NPM_TOKEN }}
 


### PR DESCRIPTION
修复 .npmrc 使用 npmmirror 镜像导致发布认证失败的问题